### PR TITLE
always retry jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	. ./local.sh && . ./secrets/.secrets && pipenv run py.test ./test.py
 
 shell:
-	pipenv run ipython
+	. ./local.sh && . ./secrets/.secrets && pipenv run ipython
 
 run-prod:
 	. ./prod.sh && . ./secrets/.secrets && gunicorn -b localhost:3000 payment.app:app

--- a/payment/errors.py
+++ b/payment/errors.py
@@ -26,3 +26,7 @@ class WalletNotFoundError(BaseError):
 
 class ParseError(ValueError):
     pass
+
+
+class PersitentError(Exception):
+    """an error that shouldn't be retried."""

--- a/payment/queue.py
+++ b/payment/queue.py
@@ -2,7 +2,7 @@ import kin
 from rq import Queue
 import requests
 from . import config
-from .errors import PaymentNotFoundError
+from .errors import PaymentNotFoundError, PersitentError
 from .log import get as get_log
 from .models import Payment, PaymentRequest, WalletRequest, Wallet
 from .utils import retry, lock
@@ -193,6 +193,8 @@ def pay(payment_request: PaymentRequest):
         statsd.inc_count('transaction.paid',
                          payment_request.amount,
                          tags=['app_id:%s' % payment_request.app_id])
+    except (AccountNotFoundError, AccountNotActivatedError) as e:
+        raise PersitentError(e)
     except Exception as e:
         statsd.increment('transaction.failed',
                          tags=['app_id:%s' % payment_request.app_id])

--- a/worker.py
+++ b/worker.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+  #!/usr/bin/env python
 import sys
-from rq import Connection, Worker
-from rq.job import Job
+from rq import Connection, Worker, Queue
+from rq.job import Job, JobStatus
 
 # Preload libraries
 from payment.statsd import statsd
@@ -11,11 +11,17 @@ from payment.redis_conn import redis_conn
 
 
 log = get_log()
+q = Queue(connection=redis_conn)
 
 
 def rq_error_handler(job: Job, exc_type, exc_value, traceback):
     statsd.increment('worker_error', tags=['job:%s' % job.func_name, 'error_type:%s' % exc_type, 'error:%s' % exc_value])
     log.error('worker error in job', func_name=job.func_name, args=job.args, exc_info=(exc_type, exc_value, traceback))
+
+    # reset job state and retry the job
+    job.set_status(JobStatus.QUEUED)
+    job.exc_info = None
+    q.enqueue_job(job)
 
 
 with Connection():

--- a/worker.py
+++ b/worker.py
@@ -7,6 +7,7 @@ from rq.job import Job, JobStatus
 from payment.statsd import statsd
 from payment.log import get as get_log
 from payment import config
+from payment.errors import PersitentError
 from payment.redis_conn import redis_conn
 
 
@@ -19,12 +20,17 @@ def rq_error_handler(job: Job, exc_type, exc_value, traceback):
     log.error('worker error in job', func_name=job.func_name, args=job.args, exc_info=(exc_type, exc_value, traceback))
 
     # reset job state and retry the job
-    job.set_status(JobStatus.QUEUED)
-    job.exc_info = None
-    q.enqueue_job(job)
+    if exc_type != PersitentError:
+        job.set_status(JobStatus.QUEUED)
+        job.exc_info = None
+        q.enqueue_job(job)
+    else:
+        statsd.increment('worker_persistent_error', tags=['job:%s' % job.func_name, 'error_type:%s' % exc_type, 'error:%s' % exc_value])
+        log.error('not retriying PersitentError', e=exc_value)
 
 
-with Connection():
-    queue_names = ['default']
-    w = Worker(queue_names, connection=redis_conn, exception_handlers=[rq_error_handler])
-    w.work()
+if __name__ == '__main__':
+    with Connection():
+        queue_names = ['default']
+        w = Worker(queue_names, connection=redis_conn, exception_handlers=[rq_error_handler])
+        w.work()


### PR DESCRIPTION
This change will make failed jobs go back into the queue and will be retried by another worker.
This still doesn't ensure "at-least-once" behaviour because jobs might crash the process and won't reach the requeue part of the code.